### PR TITLE
fix(#38): migrate agents to use tool structured outputs

### DIFF
--- a/planning_files/learnmate-sprint-plan.md
+++ b/planning_files/learnmate-sprint-plan.md
@@ -57,6 +57,7 @@
 | Feature 2: Flashcard Gen Agent (Completed) | |
 | Feature 3: Quiz Gen Agent & API (Completed) | |
 | Quiz submission API + answer storage (Completed) | |
+| Bugfix (Issue #38): Migrate AI agents to use tool structured outputs (Completed) | |
 | Eval system for outputs | |
 | Store eval history in DB for reporting | Eval quality badge display on generated content |
 

--- a/server/src/agents/flashcard_agent.py
+++ b/server/src/agents/flashcard_agent.py
@@ -73,14 +73,42 @@ def generate_flashcards(
                 "content": build_user_message(module_content, student_notes),
             }
         ],
+        tools=[
+            {
+                "name": "generate_flashcards_output",
+                "description": "Output the final generated flashcards.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "flashcards": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "question": {"type": "string"},
+                                    "answer": {"type": "string"},
+                                    "difficulty": {"type": "integer"},
+                                    "bloom_level": {
+                                        "type": "string", 
+                                        "enum": ["Remember", "Understand", "Apply", "Analyze", "Evaluate", "Create"]
+                                    }
+                                },
+                                "required": ["question", "answer", "difficulty", "bloom_level"]
+                            }
+                        }
+                    },
+                    "required": ["flashcards"]
+                }
+            }
+        ],
+        tool_choice={"type": "tool", "name": "generate_flashcards_output"}
     )
 
-    raw = message.content[0].text
-    try:
-        flashcards: list[dict] = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        logger.error("Claude returned non-JSON response: %s", raw)
-        raise ValueError(f"Claude API returned invalid JSON: {raw!r}") from exc
+    tool_use = next((block for block in message.content if block.type == "tool_use"), None)
+    if not tool_use:
+        raise ValueError(f"Claude API returned no structured output. Response: {message.content}")
+
+    flashcards: list[dict] = tool_use.input.get("flashcards", [])
 
     _validate_flashcards(flashcards)
     logger.info("Generated %d flashcards.", len(flashcards))

--- a/server/src/agents/quiz_agent.py
+++ b/server/src/agents/quiz_agent.py
@@ -96,14 +96,46 @@ def generate_quiz(
                 ),
             }
         ],
+        tools=[
+            {
+                "name": "generate_quiz_output",
+                "description": "Output the generated quiz.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string"},
+                        "difficulty_level": {"type": "string", "enum": ["Easy", "Medium", "Hard"]},
+                        "questions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {"type": "integer"},
+                                    "text": {"type": "string"},
+                                    "question_type": {"type": "string", "enum": ["multiple_choice", "short_answer"]},
+                                    "options": {
+                                        "type": ["array", "null"],
+                                        "items": {"type": "string"}
+                                    },
+                                    "correct_answer": {"type": "string"},
+                                    "explanation": {"type": "string"}
+                                },
+                                "required": ["id", "text", "question_type", "correct_answer", "explanation"]
+                            }
+                        }
+                    },
+                    "required": ["title", "difficulty_level", "questions"]
+                }
+            }
+        ],
+        tool_choice={"type": "tool", "name": "generate_quiz_output"}
     )
 
-    raw = message.content[0].text
-    try:
-        quiz: dict = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        logger.error("Claude returned non-JSON response: %s", raw)
-        raise ValueError(f"Claude API returned invalid JSON: {raw!r}") from exc
+    tool_use = next((block for block in message.content if block.type == "tool_use"), None)
+    if not tool_use:
+        raise ValueError(f"Claude API returned no structured output. Response: {message.content}")
+
+    quiz: dict = tool_use.input
 
     _validate_quiz(quiz)
     logger.info(

--- a/server/src/agents/summary_agent.py
+++ b/server/src/agents/summary_agent.py
@@ -92,14 +92,33 @@ def generate_summary(
                 ),
             }
         ],
+        tools=[
+            {
+                "name": "generate_summary_output",
+                "description": "Output the final generated summary.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string"},
+                        "content": {"type": "string"},
+                        "word_count": {"type": "integer"},
+                        "summary_level": {
+                            "type": "string", 
+                            "enum": ["Brief", "Standard", "Detailed"]
+                        }
+                    },
+                    "required": ["title", "content", "word_count", "summary_level"]
+                }
+            }
+        ],
+        tool_choice={"type": "tool", "name": "generate_summary_output"}
     )
 
-    raw = message.content[0].text
-    try:
-        summary: dict = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        logger.error("Claude returned non-JSON response: %s", raw)
-        raise ValueError(f"Claude API returned invalid JSON: {raw!r}") from exc
+    tool_use = next((block for block in message.content if block.type == "tool_use"), None)
+    if not tool_use:
+        raise ValueError(f"Claude API returned no structured output. Response: {message.content}")
+
+    summary: dict = tool_use.input
 
     _validate_summary(summary)
     logger.info("Generated summary with %d words.", summary.get("word_count", 0))

--- a/server/tests/test_flashcard_agent.py
+++ b/server/tests/test_flashcard_agent.py
@@ -81,8 +81,12 @@ def _make_mock_client(flashcards: list[dict]) -> tuple[MagicMock, MagicMock]:
         A tuple of (mock_anthropic_cls, mock_client) ready for use with patch().
     """
     mock_message = MagicMock()
-    mock_message.content = [MagicMock()]
-    mock_message.content[0].text = json.dumps(flashcards)
+    
+    mock_tool_use = MagicMock()
+    mock_tool_use.type = "tool_use"
+    mock_tool_use.input = {"flashcards": flashcards}
+    
+    mock_message.content = [mock_tool_use]
 
     mock_client = MagicMock()
     mock_client.messages.create.return_value = mock_message
@@ -253,20 +257,22 @@ class TestLongInput:
 
 
 class TestJsonParseFailure:
-    """Agent raises ValueError when Claude returns non-JSON text."""
+    """Agent raises ValueError when Claude returns text without tool_use."""
 
     def test_non_json_response_raises_value_error(self) -> None:
-        """A plain-text Claude response causes a ValueError with 'invalid JSON'."""
+        """A plain-text Claude response causes a ValueError with 'structured output'."""
         mock_message = MagicMock()
-        mock_message.content = [MagicMock()]
-        mock_message.content[0].text = "Sorry, I cannot generate flashcards for that."
+        mock_text = MagicMock()
+        mock_text.type = "text"
+        mock_text.text = "Sorry, I cannot generate flashcards for that."
+        mock_message.content = [mock_text]
 
         mock_client = MagicMock()
         mock_client.messages.create.return_value = mock_message
         mock_cls = MagicMock(return_value=mock_client)
 
         with patch("src.agents.flashcard_agent.anthropic.Anthropic", mock_cls):
-            with pytest.raises(ValueError, match="invalid JSON"):
+            with pytest.raises(ValueError, match="structured output"):
                 generate_flashcards(
                     module_content=MODULE_CONTENT, student_notes=STUDENT_NOTES
                 )

--- a/server/tests/test_quiz_agent.py
+++ b/server/tests/test_quiz_agent.py
@@ -162,8 +162,12 @@ def _make_mock_client(quiz: dict) -> tuple[MagicMock, MagicMock]:
         A tuple of (mock_anthropic_cls, mock_client) ready for use with patch().
     """
     mock_message = MagicMock()
-    mock_message.content = [MagicMock()]
-    mock_message.content[0].text = json.dumps(quiz)
+    
+    mock_tool_use = MagicMock()
+    mock_tool_use.type = "tool_use"
+    mock_tool_use.input = quiz
+    
+    mock_message.content = [mock_tool_use]
 
     mock_client = MagicMock()
     mock_client.messages.create.return_value = mock_message
@@ -542,20 +546,22 @@ class TestValidation:
 
 
 class TestJsonParseFailure:
-    """Agent raises ValueError when Claude returns non-JSON text."""
+    """Agent raises ValueError when Claude returns text without tool_use."""
 
     def test_non_json_response_raises_value_error(self) -> None:
-        """A plain-text Claude response causes a ValueError with 'invalid JSON'."""
+        """A plain-text Claude response causes a ValueError with 'structured output'."""
         mock_message = MagicMock()
-        mock_message.content = [MagicMock()]
-        mock_message.content[0].text = "I cannot generate a quiz for that content."
+        mock_text = MagicMock()
+        mock_text.type = "text"
+        mock_text.text = "I cannot generate a quiz for that content."
+        mock_message.content = [mock_text]
 
         mock_client = MagicMock()
         mock_client.messages.create.return_value = mock_message
         mock_cls = MagicMock(return_value=mock_client)
 
         with patch("src.agents.quiz_agent.anthropic.Anthropic", mock_cls):
-            with pytest.raises(ValueError, match="invalid JSON"):
+            with pytest.raises(ValueError, match="structured output"):
                 generate_quiz(
                     module_content=MODULE_CONTENT, student_notes=STUDENT_NOTES
                 )

--- a/server/tests/test_summary_agent.py
+++ b/server/tests/test_summary_agent.py
@@ -63,8 +63,12 @@ def _make_mock_client(summary: dict) -> tuple[MagicMock, MagicMock]:
         A tuple of (mock_anthropic_cls, mock_client) ready for use with patch().
     """
     mock_message = MagicMock()
-    mock_message.content = [MagicMock()]
-    mock_message.content[0].text = json.dumps(summary)
+    
+    mock_tool_use = MagicMock()
+    mock_tool_use.type = "tool_use"
+    mock_tool_use.input = summary
+    
+    mock_message.content = [mock_tool_use]
 
     mock_client = MagicMock()
     mock_client.messages.create.return_value = mock_message
@@ -268,20 +272,22 @@ class TestLongInput:
 
 
 class TestJsonParseFailure:
-    """Agent raises ValueError when Claude returns non-JSON text."""
+    """Agent raises ValueError when Claude returns text without tool_use."""
 
     def test_non_json_response_raises_value_error(self) -> None:
-        """A plain-text Claude response causes a ValueError with 'invalid JSON'."""
+        """A plain-text Claude response causes a ValueError with 'structured output'."""
         mock_message = MagicMock()
-        mock_message.content = [MagicMock()]
-        mock_message.content[0].text = "I cannot summarise that content."
+        mock_text = MagicMock()
+        mock_text.type = "text"
+        mock_text.text = "I cannot summarise that content."
+        mock_message.content = [mock_text]
 
         mock_client = MagicMock()
         mock_client.messages.create.return_value = mock_message
         mock_cls = MagicMock(return_value=mock_client)
 
         with patch("src.agents.summary_agent.anthropic.Anthropic", mock_cls):
-            with pytest.raises(ValueError, match="invalid JSON"):
+            with pytest.raises(ValueError, match="structured output"):
                 generate_summary(
                     module_content=MODULE_CONTENT, student_notes=STUDENT_NOTES
                 )


### PR DESCRIPTION
Closes #38. Migrated quiz, flashcard, and summary code to use pure structured output schemas natively via Anthropic Tool Use API