### PR TITLE
fix(#40): fix stringified tool output parsing and refine prompts

### DIFF
--- a/planning_files/learnmate-sprint-plan.md
+++ b/planning_files/learnmate-sprint-plan.md
@@ -58,6 +58,7 @@
 | Feature 3: Quiz Gen Agent & API (Completed) | |
 | Quiz submission API + answer storage (Completed) | |
 | Bugfix (Issue #38): Migrate AI agents to use tool structured outputs (Completed) | |
+| Bugfix (Issue #40): Fix stringified tool output parsing and refine AI prompts (Completed) | |
 | Eval system for outputs | |
 | Store eval history in DB for reporting | Eval quality badge display on generated content |
 

--- a/server/src/agents/flashcard_agent.py
+++ b/server/src/agents/flashcard_agent.py
@@ -109,6 +109,12 @@ def generate_flashcards(
         raise ValueError(f"Claude API returned no structured output. Response: {message.content}")
 
     flashcards: list[dict] = tool_use.input.get("flashcards", [])
+    if isinstance(flashcards, str):
+        import json
+        try:
+            flashcards = json.loads(flashcards)
+        except Exception:
+            pass
 
     _validate_flashcards(flashcards)
     logger.info("Generated %d flashcards.", len(flashcards))
@@ -142,18 +148,18 @@ def _maybe_truncate(module_content: str, student_notes: str) -> tuple[str, str]:
 
 
 def _validate_flashcards(flashcards: list[dict]) -> None:
-    """Validate that each flashcard returned by Claude has the required fields.
+    """Validate that the list of flashcard dicts meets requirements.
 
     Args:
-        flashcards: Raw list parsed from Claude's JSON response.
+        flashcards: The list of flashcard dicts returned by Claude.
 
     Raises:
-        ValueError: If the response is not a list, or any card is missing a
-            required field or contains an out-of-range value.
+        ValueError: If the response is not a list, contains an invalid number of
+            cards, or any card fails field validation.
     """
     if not isinstance(flashcards, list):
         raise ValueError(
-            f"Expected a JSON array from Claude, got: {type(flashcards).__name__}"
+            f"Expected a list of flashcards, got: {type(flashcards).__name__}"
         )
 
     for i, card in enumerate(flashcards):

--- a/server/src/agents/prompts/flashcard_prompt.py
+++ b/server/src/agents/prompts/flashcard_prompt.py
@@ -19,7 +19,7 @@ Rules:
 - Blend both the course material and the student notes so that roughly half the \
 cards draw from each source.
 - If one source is empty, generate all cards from the other source.
-- Return ONLY a valid JSON array with no extra text. Each element must be an \
+- Use the provided structured output tool schema. Each element must be an \
 object with exactly four fields:
     "question"   (string)  — the flashcard question
     "answer"     (string)  — the flashcard answer

--- a/server/src/agents/prompts/quiz_prompt.py
+++ b/server/src/agents/prompts/quiz_prompt.py
@@ -19,7 +19,7 @@ Rules:
 - At least 1 question must be short_answer.
 - Every multiple_choice question must have exactly 4 options.
 - short_answer questions must have options set to null.
-- Return ONLY a valid JSON object with no extra text. The object must have \
+- Use the provided structured output tool schema. The object must have \
 exactly three top-level keys:
     "title"           (string)  — a concise title for the quiz
     "difficulty_level" (string) — one of: Easy, Medium, Hard

--- a/server/src/agents/prompts/summary_prompt.py
+++ b/server/src/agents/prompts/summary_prompt.py
@@ -20,7 +20,7 @@ Rules:
 - Blend both sources so the summary reflects concepts from the course material \
 AND the student notes.
 - If one source is empty, summarise the other source only.
-- Return ONLY a valid JSON object with no extra text. The object must have \
+- Use the provided structured output tool schema. The object must have \
 exactly four fields:
     "title"         (string)  — a concise title for the summary
     "content"       (string)  — the summary text at the requested level

--- a/server/src/agents/quiz_agent.py
+++ b/server/src/agents/quiz_agent.py
@@ -206,6 +206,14 @@ def _validate_quiz(quiz: dict) -> None:
         )
 
     questions = quiz["questions"]
+    if isinstance(questions, str):
+        import json
+        try:
+            questions = json.loads(questions)
+            quiz["questions"] = questions
+        except Exception:
+            pass
+
     if not isinstance(questions, list):
         raise ValueError(
             f"Quiz 'questions' must be a list, got: {type(questions).__name__}"

--- a/server/src/agents/summary_agent.py
+++ b/server/src/agents/summary_agent.py
@@ -119,6 +119,12 @@ def generate_summary(
         raise ValueError(f"Claude API returned no structured output. Response: {message.content}")
 
     summary: dict = tool_use.input
+    if isinstance(summary, str):
+        import json
+        try:
+            summary = json.loads(summary)
+        except Exception:
+            pass
 
     _validate_summary(summary)
     logger.info("Generated summary with %d words.", summary.get("word_count", 0))


### PR DESCRIPTION
Closes #40. Added JSON fallback parsing when Claude strings tool JSON arrays, and removed conflicting instructions from system prompts.