### PR TITLE
chore: Add Vercel config for frontend API routing (#58)

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,0 +1,16 @@
+{
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "https://learnmate-api.onrender.com/api/:path*"
+    },
+    {
+      "source": "/uploads/:path*",
+      "destination": "https://learnmate-api.onrender.com/uploads/:path*"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #58. Adds vercel.json to rewrite /api and /uploads traffic to Render API.